### PR TITLE
fix #5; remove error message on startup

### DIFF
--- a/app/ui.R
+++ b/app/ui.R
@@ -78,8 +78,8 @@ ui <- page_navbar(
     selectInput(
       "filter_map",
       "Maps:",
-      choices = NULL,
-      selected = NULL,
+      choices = c("Ascent"),
+      selected = "Ascent",
       multiple = TRUE
     ) |>
       tooltip(TT_HOW_TO_DELETE),
@@ -88,8 +88,8 @@ ui <- page_navbar(
     selectInput(
       "filter_agent",
       "Agents:",
-      choices = NULL,
-      selected = NULL,
+      choices = c("Cypher"),
+      selected = "Cypher",
       multiple = TRUE
     ) |>
       tooltip(TT_HOW_TO_DELETE),


### PR DESCRIPTION
The issue here was that the starting values in the gobal filters were `NULL`, which caused the red error messages on startup. Setting dummy values fixed it. Once the data is loaded, the filters' contents is loaded from the data, so the dummy values are just placeholders to prevent the ugly error messages.